### PR TITLE
WL-1445 Different sub sites have different icons

### DIFF
--- a/portal-render-engine-impl/pack/src/webapp/vm/defaultskin/includePageNav.vm
+++ b/portal-render-engine-impl/pack/src/webapp/vm/defaultskin/includePageNav.vm
@@ -84,7 +84,7 @@
 			<!-- Add subsite lists --> 
 			#foreach ( $site in $children ) 
 				        <li>
-				             <a class="${sitePages.subsiteClass} #if(!${site.isPublished})unpublished#end" href="${site.siteUrl}" title="${site.shortDescription}">
+				             <a class="${site.type} #if(!${site.isPublished})unpublished#end" href="${site.siteUrl}" title="${site.shortDescription}">
 				             <span>${site.siteTitle}</span>
 				             </a>
 				        </li>


### PR DESCRIPTION
This is so that redirects can have different icons from sites.
