### PR TITLE
WL-7 Allow hierarchy to claim /site URLs.

### DIFF
--- a/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -2118,16 +2118,21 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		// warning messages will appear, but the end state will be the same.
 		portalService.addPortal(this);
 
+		// We create second instances of these two handlers as they are used internally for error handling
+		// and otherwise if another handler claims the URLs they get de-registered and then the
+		// error handling stops working.
 		worksiteHandler = new WorksiteHandler();
+		worksiteHandler.register(this, portalService, getServletContext());
 		siteHandler = new SiteHandler();
+		siteHandler.register(this, portalService, getServletContext());
 
-		addHandler(siteHandler);
+		addHandler(new SiteHandler());
 		addHandler(new SiteResetHandler());
 
 		addHandler(new ToolHandler());
 		addHandler(new ToolResetHandler());
 		addHandler(new PageHandler());
-		addHandler(worksiteHandler);
+		addHandler(new WorksiteHandler());
 		addHandler(new WorksiteResetHandler());
 		addHandler(new RssHandler());
 		addHandler(new PDAHandler());

--- a/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/BasePortalHandler.java
+++ b/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/BasePortalHandler.java
@@ -88,6 +88,8 @@ public abstract class BasePortalHandler implements PortalHandler
 	 */
 	public void deregister(Portal portal)
 	{
+		// The portal is typically in a web-app and we want to allow the portal to get garbage collected so handlers
+		// shouldn't hold onto references to the portal as they may be registered in foreign web-apps.
 		this.portal = null;
 	}
 


### PR DESCRIPTION
We have our own /site handler and when we re-claim the /site URLs it stops the error handling working as the handlers get de-registered for GC purposes. So we create a special “internal” instance to allow the error handlers to carry on working.
