### PR TITLE
WL-5 Offer creation of sites if you can add managed.

### DIFF
--- a/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -861,6 +861,8 @@ public class SiteHandler extends WorksiteHandler
 				allowAddSite = true;
 			} else if (SiteService.allowAddProjectSite()) {
 				allowAddSite = true;
+			} else if (SiteService.allowAddManagedSite()) {
+				allowAddSite = true;
 			}
 
 			rcontext.put("allowAddSite",allowAddSite);


### PR DESCRIPTION
The portal now offers you a quick way to create a site, but there wasn’t a check to see if you can add managed sites which meant it wasn’t appearing for most users.
