### PR TITLE
contact_us_2_column_bug

### DIFF
--- a/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PageHandler.java
+++ b/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PageHandler.java
@@ -46,6 +46,7 @@ import org.sakaiproject.portal.api.PortalHandlerException;
 import org.sakaiproject.portal.api.PortalRenderContext;
 import org.sakaiproject.portal.api.StoredState;
 import org.sakaiproject.portal.api.Portal.LoginRoute;
+import org.sakaiproject.portal.charon.SkinnableCharonPortal;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
@@ -256,6 +257,12 @@ public class PageHandler extends BasePortalHandler
 
 			rcontext.put("pageTwoColumn", Boolean
 					.valueOf(page.getLayout() == SitePage.LAYOUT_DOUBLE_COL));
+
+			String contactUsUrlSuffix = ServerConfigurationService.getString(SkinnableCharonPortal.CONTACT_US_URL_SUFFIX, SkinnableCharonPortal.CONTACT_US_URL_DEFAULT);
+			if (req.getRequestURI().endsWith(contactUsUrlSuffix)){
+				rcontext.put("pageColumnLayout","col1");
+				rcontext.put("pageTwoColumn", false);
+			}
 
 			// do the second column if needed
 			if (page.getLayout() == SitePage.LAYOUT_DOUBLE_COL)


### PR DESCRIPTION
There's a bug where a site with a 2-column layout shows something in column 2 (Announcements, Calendar) on the page when you go to the Contact Us tool (which we don't want).
I'm setting the layout to be 1-column when it's the Contact Us tool.
