### PR TITLE
WL-3591 : Make Contact Us tool selected when clicked (not Home tool)

### DIFF
--- a/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -738,6 +738,13 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 		}
 
 		theMap.put("pageNavTools", l);
+		String contactUsUrlSuffix = ServerConfigurationService.getString(SkinnableCharonPortal.CONTACT_US_URL_SUFFIX, SkinnableCharonPortal.CONTACT_US_URL_DEFAULT);
+		if (req.getRequestURI().endsWith(contactUsUrlSuffix)){
+			for (Map map : l) {
+				map.put("current", false);
+			}
+			theMap.put("contactUsToolClass", "selectedTool");
+		}
 		theMap.put("pageMaxIfSingle", ServerConfigurationService.getBoolean(
 				"portal.experimental.maximizesinglepage", false));
 		theMap.put("pageNavToolsCount", Integer.valueOf(l.size()));

--- a/portal-render-engine-impl/pack/src/webapp/vm/neoskin/includePageNav.vm
+++ b/portal-render-engine-impl/pack/src/webapp/vm/neoskin/includePageNav.vm
@@ -63,7 +63,7 @@
 						</li>
 			#end
 			#if (${sitePages.pageNavShowFeedback})
-				<li>
+				<li class="${sitePages.contactUsToolClass}">
 					<a class="toolMenuLink" href="${sitePages.pageNavFeedbackUrl}" title="${rloader.sit_feedback_description}">
 						<span class="toolMenuIcon ${sitePages.feedbackMenuClass}"></span><span class="menuTitle">${rloader.sit_feedback}</span>
 					</a>


### PR DESCRIPTION
When Contact us is clicked, the site is kept the same so that the site's tool menu is the same (even though the Contact Us tool is in a different site).  Because of this, the original site cannot tell the Contact Us tool to be selected when clicked as it doesn't know about it.  So we need to be explicit about it.
