### PR TITLE
WL-3665 : Don't NPE when PDA Home tool selected

### DIFF
--- a/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PDAHandler.java
+++ b/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PDAHandler.java
@@ -285,7 +285,7 @@ public class PDAHandler extends SiteHandler
 					// Does the tool allow us to buffer?
 					allowBuffer = allowBufferContent(req, siteTool);
 
-					if ( allowBuffer ) {
+					if ( allowBuffer || siteTool.getToolId().equals("sakai.iframe.site") ) {
 						toolContextPath = req.getContextPath() + req.getServletPath() + Web.makePath(parts, 1, 5);
 						toolPathInfo = Web.makePath(parts, 5, parts.length);
 


### PR DESCRIPTION
For the Home tool sorry page, what is currently happening is that the Home tool ("sakai.iframe.site") is being created with a config that has an entry of 'portlet-context=/sakai-web-portlet' in it.  
(This happens in PortletTool.java, line 140: m_finalConfig.setProperty(PortalService.TOOL_PORTLET_CONTEXT_PATH, appName);)
Then, when you later click on a tool on the pda site it checks if the tool has an entry for portlet-context and if it does it creates a toolContextPath (from which it creates the resetActionUrl), but if it doesn't it will NPE when trying to create the resetActionUrl (PDAHandler.java, line 344).

It is a similar story for Web Content sorry page (sakai.iframe). 

This change says to create the toolContextPath if the tool has an entry for portlet-context or is the Home or Web Content tool. 
