### PR TITLE
WL-3783 Allow a priority for portal handlers.

### DIFF
--- a/portal-api/api/src/java/org/sakaiproject/portal/api/PortalHandler.java
+++ b/portal-api/api/src/java/org/sakaiproject/portal/api/PortalHandler.java
@@ -88,6 +88,13 @@ public interface PortalHandler
 	String getUrlFragment();
 
 	/**
+	 * Returns the priority of this handler, if you attempt to replace a handler
+	 * it will only succeed if the handler has a higher priority.
+	 * @return The priority of this handler, the default priority is 0.
+	 */
+	int getPriority();
+
+	/**
 	 * deregister the the portal, invoked by the portal
 	 * 
 	 * @param portal

--- a/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1635,7 +1635,14 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 
 	public String getPortalPageUrl(ToolConfiguration p)
 	{
-		return "/site/"+ getSiteHelper().getSiteAlias(p.getSiteId())+ "/page/" + p.getPageId();
+		SitePage sitePage = p.getContainingPage();
+		String page = getSiteHelper().lookupPageToAlias(p.getSiteId(), sitePage);
+		if (page == null)
+		{
+			// Fall back to default of using the page Id.
+			page = p.getPageId();
+		}
+		return "/site/" + getSiteHelper().getSiteAlias(p.getSiteId()) + "/page/" + page;
 	}
 
 	/**

--- a/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/BasePortalHandler.java
+++ b/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/BasePortalHandler.java
@@ -67,6 +67,8 @@ public abstract class BasePortalHandler implements PortalHandler
 
 	private String urlFragment;
 
+	private int priority = 0;
+
 	protected ServletContext servletContext;
 
 	public abstract int doGet(String[] parts, HttpServletRequest req,
@@ -139,7 +141,23 @@ public abstract class BasePortalHandler implements PortalHandler
 	{
 		this.urlFragment = urlFragment;
 	}
-	
+
+	/**
+	 * @return The priority of this handler.
+	 */
+	@Override
+	public int getPriority()
+	{
+		return priority;
+	}
+
+	/**
+	 * @param priority the priority of this handler.
+	 */
+	public void setPriority(int priority)
+	{
+		this.priority = priority;
+	}
 	/**
 	 * *
 	 * 

--- a/portal-service-impl/impl/pom.xml
+++ b/portal-service-impl/impl/pom.xml
@@ -60,6 +60,11 @@
             <groupId>org.apache.pluto</groupId>
             <artifactId>pluto-descriptor-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
+++ b/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
@@ -397,9 +397,15 @@ public class PortalServiceImpl implements PortalService
 		PortalHandler ph = handlerMap.get(urlFragment);
 		if (ph != null)
 		{
-			handler.deregister(portal);
-			log.warn("Handler Present on  " + urlFragment + " will replace " + ph
-					+ " with " + handler);
+			if (ph.getPriority() > handler.getPriority()) {
+				log.info("Handler on "+ urlFragment + " will not be replaced with "+ handler +
+				" as it's priority is lower.");
+				return;
+			} else {
+				ph.deregister(portal);
+				log.warn("Handler Present on  " + urlFragment + " will replace " + ph
+						+ " with " + handler);
+			}
 		}
 		handler.register(portal, this, portal.getServletContext());
 		handlerMap.put(urlFragment, handler);
@@ -415,8 +421,15 @@ public class PortalServiceImpl implements PortalService
 		if (portal == null)
 		{
 			Map<String, PortalHandler> handlerMap = getHandlerMap(portalContext, true);
-			handlerMap.put(handler.getUrlFragment(), handler);
-			log.debug("Registered handler ("+ handler+ ") for portal ("+portalContext+ ") that doesn't yet exist.");
+			PortalHandler existingHandler = handlerMap.get(handler.getUrlFragment());
+			if (existingHandler != null && existingHandler.getPriority() > handler.getPriority()) {
+				log.debug("Handler on "+ handler.getUrlFragment() + " will not be replaced with "+ handler +
+						" as it's priority is lower.");
+			}
+			else {
+				handlerMap.put(handler.getUrlFragment(), handler);
+				log.debug("Registered handler (" + handler + ") for portal (" + portalContext + ") that doesn't yet exist.");
+			}
 		}
 		else
 		{

--- a/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceImplHandlerTest.java
+++ b/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceImplHandlerTest.java
@@ -1,0 +1,128 @@
+package org.sakaiproject.portal.service;
+
+import org.apache.commons.logging.LogFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.sakaiproject.portal.api.Portal;
+import org.sakaiproject.portal.api.PortalHandler;
+import org.sakaiproject.portal.service.PortalServiceImpl;
+
+import javax.servlet.ServletContext;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * This set of tests was written to check that giving portal handlers a priority worked.
+ *
+ * Created by buckett on 27/01/15.
+ */
+public class PortalServiceImplHandlerTest {
+
+    private PortalServiceImpl service;
+    private ServletContext context;
+
+    @Before
+    public void setUp() {
+        // Disable logging
+        LogFactory.getFactory().setAttribute(
+                "org.apache.commons.logging.Log",
+                "org.apache.commons.logging.impl.NoOpLog");
+
+        service = new PortalServiceImpl();
+        context = mock(ServletContext.class);
+    }
+
+    @Test
+    public void testAddHandlerNoPortal() {
+        // Check when there's no portal that a handler of the same priority takes precedence.
+        PortalHandler ph1 = mockPortalHandler("/handler", 0);
+        PortalHandler ph2 = mockPortalHandler("/handler", 0);
+
+        service.addHandler("portal", ph1);
+        service.addHandler("portal", ph2);
+
+        Portal portal = mockPortal();
+
+        verify(ph1, never()).register(portal, service, context);
+        verify(ph2).register(portal, service, context);
+
+        Map<String, PortalHandler> handlerMap = service.getHandlerMap(portal);
+        assertTrue(handlerMap.containsKey("/handler"));
+        assertEquals(ph2, handlerMap.get("/handler"));
+        assertNotEquals(ph1, handlerMap.get("/handler"));
+    }
+
+    @Test
+    public void testAddHandlerWithPortal() {
+        // Check when there is a portal that the later handler is returned.
+        Portal portal = mockPortal();
+
+        PortalHandler ph1 = mockPortalHandler("/handler", 0);
+        PortalHandler ph2 = mockPortalHandler("/handler", 0);
+
+        service.addHandler("portal", ph1);
+        service.addHandler("portal", ph2);
+
+        verify(ph1).register(portal, service, context);
+        verify(ph1).deregister(portal);
+        verify(ph2).register(portal, service, context);
+
+        Map<String, PortalHandler> handlerMap = service.getHandlerMap(portal);
+        assertTrue(handlerMap.containsKey("/handler"));
+        assertEquals(ph2, handlerMap.get("/handler"));
+        assertNotEquals(ph1, handlerMap.get("/handler"));
+    }
+
+    @Test
+    public void testAddHandlerPriorityNoPortal() {
+        // Check when there is a portal that the higher priority handler is returned
+        PortalHandler ph1 = mockPortalHandler("/handler", 10);
+        PortalHandler ph2 = mockPortalHandler("/handler", 0);
+
+        service.addHandler("portal", ph1);
+        service.addHandler("portal", ph2);
+
+        Portal portal = mockPortal();
+
+        Map<String, PortalHandler> handlerMap = service.getHandlerMap(portal);
+        assertTrue(handlerMap.containsKey("/handler"));
+        assertEquals(ph1, handlerMap.get("/handler"));
+        assertNotEquals(ph2, handlerMap.get("/handler"));
+    }
+
+    @Test
+    public void testAddHandlerPriorityWithPortal() {
+        // Check when there is a portal that the higher priority handler is returned
+        Portal portal = mockPortal();
+
+        PortalHandler ph1 = mockPortalHandler("/handler", 10);
+        PortalHandler ph2 = mockPortalHandler("/handler", 0);
+
+        service.addHandler("portal", ph1);
+        service.addHandler("portal", ph2);
+
+        Map<String, PortalHandler> handlerMap = service.getHandlerMap(portal);
+        assertTrue(handlerMap.containsKey("/handler"));
+        assertEquals(ph1, handlerMap.get("/handler"));
+        assertNotEquals(ph2, handlerMap.get("/handler"));
+    }
+
+    // Create a mock portal handler.
+    protected PortalHandler mockPortalHandler(String fragment, int priority) {
+        PortalHandler ph1 = mock(PortalHandler.class);
+        when(ph1.getUrlFragment()).thenReturn(fragment);
+        when(ph1.getPriority()).thenReturn(priority);
+        return ph1;
+    }
+
+    // Create a mock portal.
+    protected Portal mockPortal() {
+        Portal portal = mock(Portal.class);
+        when(portal.getPortalContext()).thenReturn("portal");
+        when(portal.getServletContext()).thenReturn(context);
+        service.addPortal(portal);
+        return portal;
+    }
+}


### PR DESCRIPTION
This allows extra code to replace the standard portal handlers supplied by the portal without requiring fixed webapp load orders.
