### PR TITLE
WL-3821 Complete portlet registration if early.

### DIFF
--- a/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/SakaiPortletRegistryListener.java
+++ b/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/SakaiPortletRegistryListener.java
@@ -30,6 +30,7 @@ import javax.servlet.ServletContext;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.pluto.PortletContainerException;
 import org.apache.pluto.core.PortletContextManager;
 import org.apache.pluto.descriptors.portlet.PortletAppDD;
 import org.apache.pluto.descriptors.portlet.PortletDD;
@@ -61,6 +62,7 @@ public class SakaiPortletRegistryListener implements PortletRegistryListener
 	 * @see org.apache.pluto.spi.optional.PortletRegistryListener#portletApplicationRegistered(org.apache.pluto.spi.optional.PortletRegistryEvent)
 	 */
 	@SuppressWarnings("unchecked")
+	@Override
 	public void portletApplicationRegistered(PortletRegistryEvent evt)
 	{
 		try
@@ -165,6 +167,23 @@ public class SakaiPortletRegistryListener implements PortletRegistryListener
 	public void init()
 	{
 		registry = PortletContextManager.getManager();
+
+		Iterator<String> ids = registry.getRegisteredPortletApplicationIds();
+		// Portlets may have been registered before we managed to add our listener.
+		while(ids.hasNext())
+		{
+			String id = ids.next();
+			try {
+				PortletAppDD appDD = registry.getPortletApplicationDescriptor(id);
+				PortletRegistryEvent event = new PortletRegistryEvent();
+				event.setApplicationId(id);
+				event.setPortletApplicationDescriptor(appDD);
+				portletApplicationRegistered(event);
+				log.info("Re-registered early portlet: "+ id);
+			} catch (PortletContainerException e) {
+				log.error("Failed to re-register portlet: "+ id, e);
+			}
+		}
 		registry.addPortletRegistryListener(this);
 	}
 


### PR DESCRIPTION
If a portlet gets registered early in startup (before the component manager is up) then the Sakai tools that are associated with it don’t get processed as the listener isn’t added yet.

This changes the initialisation so that it sends the already registered portlets to the Sakai listener.
