### PR TITLE
WL-281 Cope with people not being in heartbeatMap.

### DIFF
--- a/portal-chat/tool/src/java/org/sakaiproject/portal/chat/entity/PCServiceEntityProvider.java
+++ b/portal-chat/tool/src/java/org/sakaiproject/portal/chat/entity/PCServiceEntityProvider.java
@@ -547,7 +547,12 @@ public final class PCServiceEntityProvider extends AbstractEntityProvider implem
 				UserMessage heartbeat = heartbeatMap.get(user.getId());
 				// Flag this user as offline if they can't access portal chat
 				boolean offline = !portalChatPermittedHelper.checkChatPermitted(user.getId());
-				presentUsers.add(new PortalChatUser(user.getId(), user.getDisplayName(), offline, heartbeatMap.get(user.getId()).content));
+				// If the DB and the jGroups have got out of sync there might not be any entry in the heartbeat map.
+				if (heartbeat == null) {
+					logger.info("Failed to find " + user.getId() + " in heartbeat map.");
+				} else {
+					presentUsers.add(new PortalChatUser(user.getId(), user.getDisplayName(), offline, heartbeat.content));
+				}
 			}
         }
 		


### PR DESCRIPTION
When someone is present in the database of users present but isn’t 
visible in the the jGroups heartbeat map a NPE is generated. This
switches to just logging that it’s happening so that an administrator
is aware something is wrong.
