### PR TITLE
WL 4001 Quick Link dropdown closes when clicked anywhere outside the dropdown.

### DIFF
--- a/portal-charon/charon/src/webapp/scripts/neoscripts.js
+++ b/portal-charon/charon/src/webapp/scripts/neoscripts.js
@@ -764,6 +764,10 @@ var dhtml_view_quicklinks = function(){
             });
             createDHTMLMask(dhtml_view_quicklinks);
         }
+        else {
+            //hide the dropdown when clicked outside the div
+            closeQuickLinksDrawer();
+        }
     }
     // finally run the inner function, first time through
     dhtml_view_quicklinks();


### PR DESCRIPTION
If clicked outside in the masked area 'quick link' dropdown closes without clicking on the 'X' button.
Checked on I.E 11, Firefox and Chrome.
